### PR TITLE
setup.py skipped the installation of 'install_required' packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build
 dist
 occiput.egg-info
 occiput/notebooks/.ipynb_checkpoints
+occiput/__pycache__
+occiput/Core/__pycache__

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,9 @@
 # Use old Python build system, otherwise the extension libraries cannot be found. FIXME
 import sys
 
-for arg in sys.argv:
-    if arg == "install":
-        sys.argv.append("--old-and-unmanageable")
+# for arg in sys.argv:
+#     if arg == "install":
+#         sys.argv.append("--old-and-unmanageable")
 
 from setuptools import setup, Extension
 from glob import glob


### PR DESCRIPTION
There was a check in the setup.py file that prevents the installation of required packages via pypi.

In this new version, the check is just commented out, and not removed. We should see if the integration of additional modules (Interfile, NiftyPy, etc.) into Occiput, and the subsequent modification of setup.py file would need again this check to be made.

This is a minor change that could be directly merged to develop branch.